### PR TITLE
Create init for access to yann and modify test_import

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+"""
+__init__.py - provides access to the YANN module without requiring installation
+"""
+
+import os
+import sys
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(current_dir))

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,9 +1,29 @@
-import imp 
+"""
+test_imports.py - Unit tests for YANN toolbox required imports
+"""
 
-class TestImports:
-    def test_progressbar(self): assert imp.find_module('progressbar')
-    def test_skdata(self): assert imp.find_module('skdata')
-    def test_scipy(self): assert imp.find_module('scipy')
-    def test_numpy(self): assert imp.find_module('numpy')
-    def test_theano(self): assert imp.find_module('theano')
-    def test_yann(self): assert imp.find_module('yann')
+import imp
+import unittest
+
+
+class TestImports(unittest.TestCase):
+
+    @unittest.skip("progressbar is a Python2 exclusive requirement")
+    def test_progressbar(self):
+        self.assertTrue(imp.find_module('progressbar'))
+
+    @unittest.skip("skdata is an optional data import not a requirement")
+    def test_skdata(self):
+        self.assertTrue(imp.find_module('skdata'))
+
+    def test_scipy(self):
+        self.assertTrue(imp.find_module('scipy'))
+
+    def test_numpy(self):
+        self.assertTrue(imp.find_module('numpy'))
+
+    def test_theano(self):
+        self.assertTrue(imp.find_module('theano'))
+
+    def test_yann(self):
+        self.assertTrue(imp.find_module('yann'))


### PR DESCRIPTION
Create init to provide access to YANN module without installation and modify test_imports for use with unittest instead of pytest